### PR TITLE
Add cache-scaling benchmarks and analysis for SoA vs AoS layouts

### DIFF
--- a/cache_bench_test.go
+++ b/cache_bench_test.go
@@ -1,0 +1,206 @@
+package arboreal_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"unsafe"
+
+	arboreal "github.com/stillmatic/arboreal"
+)
+
+// Cache-scaling benchmarks: SoA vs AoS at different ensemble sizes.
+//
+// Actual mortgage model trees average 23 nodes (not 127), so the real
+// per-tree footprints are:
+//   - SoA: ~391 bytes (full), ~299 bytes (hot path only)
+//   - AoS: ~552 bytes (24 bytes × 23 nodes)
+//
+// Cache boundaries (48 KB L1, 2 MB L2):
+//   - SoA fits L1: ≤125 trees    AoS fits L1: ≤89 trees
+//   - SoA fits L2: ≤5363 trees   AoS fits L2: ≤3799 trees
+//
+// Key transitions to test:
+//   - 5–50 trees:     both fit L1 comfortably
+//   - 100 trees:      SoA fits L1, AoS barely spills (the existing benchmark!)
+//   - 200–500 trees:  neither fits L1, both fit L2
+//   - 1000–2000:      both fit L2 but with increasing pressure
+//   - 4000–5000:      SoA fits L2, AoS approaches L2 limit
+//   - 8000–10000:     both exceed L2, fall back to L3
+
+var treeCounts = []int{1, 5, 10, 25, 50, 100, 200, 500, 1000, 2000, 4000, 8000}
+
+// BenchmarkCacheScalingSoA benchmarks SoA ensemble prediction at various tree counts.
+func BenchmarkCacheScalingSoA(b *testing.B) {
+	res, err := arboreal.NewGBDTFromXGBoostJSON("testdata/mortgage_xgb.json")
+	if err != nil {
+		b.Fatal(err)
+	}
+	booster := res.Learner.GradientBooster.(*arboreal.GBTModelOptimized)
+
+	maxCount := treeCounts[len(treeCounts)-1]
+	soaTrees := makeSoATrees(booster.Trees, maxCount)
+
+	features := sparseToNaNDense(vec, 44)
+
+	for _, n := range treeCounts {
+		b.Run(fmt.Sprintf("trees=%d", n), func(b *testing.B) {
+			trees := soaTrees[:n]
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var acc float32
+				for j := range trees {
+					acc += trees[j].PredictDense(features)
+				}
+				_ = acc
+			}
+		})
+	}
+}
+
+// BenchmarkCacheScalingAoS benchmarks AoS ensemble prediction at various tree counts.
+func BenchmarkCacheScalingAoS(b *testing.B) {
+	res, err := arboreal.NewGBDTFromXGBoostJSON("testdata/mortgage_xgb.json")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	maxCount := treeCounts[len(treeCounts)-1]
+	aosTrees := makeAoSTrees(res.ModelAoS.Trees, maxCount)
+
+	features := sparseToNaNDense(vec, 44)
+
+	for _, n := range treeCounts {
+		b.Run(fmt.Sprintf("trees=%d", n), func(b *testing.B) {
+			trees := aosTrees[:n]
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var acc float32
+				for j := range trees {
+					acc += trees[j].PredictDense(features)
+				}
+				_ = acc
+			}
+		})
+	}
+}
+
+// makeSoATrees creates `want` SoA trees by deep-copying from src.
+// Each tree gets its own memory allocations — no aliased backing arrays.
+func makeSoATrees(src []arboreal.TreeOptimized, want int) []arboreal.TreeOptimized {
+	out := make([]arboreal.TreeOptimized, want)
+	for i := 0; i < want; i++ {
+		s := &src[i%len(src)]
+		n := len(s.LeftChild)
+		t := arboreal.TreeOptimized{
+			LeftChild:      make([]int32, n),
+			RightChild:     make([]int32, n),
+			SplitIndex:     make([]int32, n),
+			SplitCondition: make([]float32, n),
+			DefaultLeft:    make([]bool, n),
+			HasCategorical: s.HasCategorical,
+		}
+		copy(t.LeftChild, s.LeftChild)
+		copy(t.RightChild, s.RightChild)
+		copy(t.SplitIndex, s.SplitIndex)
+		copy(t.SplitCondition, s.SplitCondition)
+		copy(t.DefaultLeft, s.DefaultLeft)
+		if s.HasCategorical {
+			t.SplitType = make([]uint8, n)
+			t.Category = make([]int32, n)
+			copy(t.SplitType, s.SplitType)
+			copy(t.Category, s.Category)
+		}
+		out[i] = t
+	}
+	return out
+}
+
+// makeAoSTrees creates `want` AoS trees by deep-copying from src.
+func makeAoSTrees(src []arboreal.TreeAoS, want int) []arboreal.TreeAoS {
+	out := make([]arboreal.TreeAoS, want)
+	for i := 0; i < want; i++ {
+		s := &src[i%len(src)]
+		t := arboreal.TreeAoS{
+			Nodes:          make([]arboreal.NodeAoS, len(s.Nodes)),
+			HasCategorical: s.HasCategorical,
+		}
+		copy(t.Nodes, s.Nodes)
+		out[i] = t
+	}
+	return out
+}
+
+// TestTreeMemoryFootprint prints actual memory footprints for analysis.
+func TestTreeMemoryFootprint(t *testing.T) {
+	res, err := arboreal.NewGBDTFromXGBoostJSON("testdata/mortgage_xgb.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	booster := res.Learner.GradientBooster.(*arboreal.GBTModelOptimized)
+
+	var totalNodes int
+	var minNodes, maxNodes int
+	minNodes = math.MaxInt
+	for i := range booster.Trees {
+		n := len(booster.Trees[i].LeftChild)
+		totalNodes += n
+		if n < minNodes {
+			minNodes = n
+		}
+		if n > maxNodes {
+			maxNodes = n
+		}
+	}
+	nTrees := len(booster.Trees)
+	avgNodes := totalNodes / nTrees
+
+	t.Logf("Model: %d trees, %d total nodes", nTrees, totalNodes)
+	t.Logf("Nodes per tree: min=%d, max=%d, avg=%d", minNodes, maxNodes, avgNodes)
+
+	soaHotPerTree := avgNodes*4*3 + avgNodes
+	soaFullPerTree := avgNodes*4*4 + avgNodes
+	aosPerTree := avgNodes * int(unsafe.Sizeof(arboreal.NodeAoS{}))
+
+	t.Logf("")
+	t.Logf("=== Per-tree memory footprint (avg %d nodes) ===", avgNodes)
+	t.Logf("SoA hot (3 arrays + bool):  %d bytes (%.1f KB)", soaHotPerTree, float64(soaHotPerTree)/1024)
+	t.Logf("SoA full (4 arrays + bool): %d bytes (%.1f KB)", soaFullPerTree, float64(soaFullPerTree)/1024)
+	t.Logf("AoS (24 bytes/node):        %d bytes (%.1f KB)", aosPerTree, float64(aosPerTree)/1024)
+	t.Logf("NodeAoS struct size:        %d bytes", unsafe.Sizeof(arboreal.NodeAoS{}))
+
+	t.Logf("")
+	t.Logf("=== Ensemble memory footprint ===")
+	t.Logf("%-8s  %-12s  %-12s  %-12s  %-10s", "Trees", "SoA hot", "SoA full", "AoS", "Ratio")
+	for _, n := range treeCounts {
+		soaH := n * soaHotPerTree
+		soaF := n * soaFullPerTree
+		aos := n * aosPerTree
+		t.Logf("%-8d  %-12s  %-12s  %-12s  %.2fx",
+			n,
+			fmtBytes(soaH), fmtBytes(soaF), fmtBytes(aos),
+			float64(aos)/float64(soaF))
+	}
+
+	t.Logf("")
+	t.Logf("=== Cache thresholds (typical Xeon) ===")
+	t.Logf("L1 data cache:  48 KB")
+	t.Logf("L2 cache:       2 MB (per core)")
+	t.Logf("L3 cache:       ~2-4 MB per core (shared)")
+	t.Logf("")
+	t.Logf("SoA full fits L1 up to:  %d trees", 48*1024/soaFullPerTree)
+	t.Logf("AoS fits L1 up to:       %d trees", 48*1024/aosPerTree)
+	t.Logf("SoA full fits L2 up to:  %d trees", 2*1024*1024/soaFullPerTree)
+	t.Logf("AoS fits L2 up to:       %d trees", 2*1024*1024/aosPerTree)
+}
+
+func fmtBytes(b int) string {
+	switch {
+	case b >= 1024*1024:
+		return fmt.Sprintf("%.1f MB", float64(b)/(1024*1024))
+	case b >= 1024:
+		return fmt.Sprintf("%.1f KB", float64(b)/1024)
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/docs/cache-scaling-analysis.md
+++ b/docs/cache-scaling-analysis.md
@@ -1,0 +1,140 @@
+# Cache Scaling Analysis: SoA vs AoS Across Ensemble Sizes
+
+Benchmark environment: `INTEL(R) XEON(R) PLATINUM 8581C CPU @ 2.10GHz`, `linux/amd64`, Go 1.24.7.
+Median of 3 runs with `-benchmem`.
+
+## Background
+
+The [refactor benchmarks](refactor-benchmarks.md) showed that at 100 trees, SoA wins the
+ensemble by ~10% despite AoS winning per-tree by ~5%. The hypothesis was that SoA's
+smaller memory footprint (~1.6 KB vs ~3 KB per tree) creates less cache pressure.
+
+This analysis tests two boundary conditions:
+1. **Both fit in cache**: Do smaller ensembles eliminate SoA's advantage?
+2. **Neither fits in cache**: Does SoA's advantage hold when both spill to L3?
+
+## Corrected Memory Footprints
+
+The original analysis assumed 127 nodes per tree. The actual mortgage model averages
+**23 nodes per tree** (min 9, max 31). This changes the arithmetic significantly:
+
+| Layout | Per tree (23 nodes) | 100 trees | 1000 trees | 8000 trees |
+|--------|-------------------|-----------|------------|------------|
+| **SoA** (4 int32 arrays + bool) | 391 B | 38 KB | 382 KB | 3.0 MB |
+| **AoS** (24 B × 23 nodes) | 552 B | 54 KB | 539 KB | 4.3 MB |
+| **Ratio** (AoS / SoA) | 1.41× | 1.41× | 1.41× | 1.41× |
+
+Cache boundaries on this Xeon (48 KB L1d, 2 MB L2 per core):
+
+| Threshold | SoA | AoS |
+|-----------|-----|-----|
+| Fits L1 (48 KB) | ≤125 trees | ≤89 trees |
+| Fits L2 (2 MB) | ≤5363 trees | ≤3799 trees |
+
+## Results
+
+| Trees | SoA (ns) | AoS (ns) | SoA ns/tree | AoS ns/tree | AoS/SoA | Cache zone |
+|------:|---------:|---------:|------------:|------------:|---------:|:-----------|
+| 1 | 12.8 | 13.7 | 12.8 | 13.7 | 1.07× | Both in L1 |
+| 5 | 58.9 | 66.6 | 11.8 | 13.3 | 1.13× | Both in L1 |
+| 10 | 118.7 | 131.3 | 11.9 | 13.1 | 1.11× | Both in L1 |
+| 25 | 296.2 | 324.0 | 11.9 | 13.0 | 1.09× | Both in L1 |
+| 50 | 597.1 | 653.5 | 11.9 | 13.1 | 1.09× | Both in L1 |
+| 100 | 1256 | 1381 | 12.6 | 13.8 | 1.10× | SoA in L1, AoS spills |
+| 200 | 2368 | 3254 | 11.8 | 16.3 | **1.37×** | Both in L2 |
+| 500 | 5894 | 8410 | 11.8 | 16.8 | **1.43×** | Both in L2 |
+| 1000 | 11626 | 16828 | 11.6 | 16.8 | **1.45×** | Both in L2 |
+| 2000 | 23687 | 33996 | 11.8 | 17.0 | **1.44×** | Both in L2 |
+| 4000 | 52866 | 83040 | 13.2 | 20.8 | **1.57×** | SoA in L2, AoS near limit |
+| 8000 | 126455 | 204016 | 15.8 | 25.5 | **1.61×** | Both spill L2 → L3 |
+
+### Per-tree cost across scales
+
+```
+ns/tree
+26 |                                                              A
+24 |
+22 |
+20 |                                            A
+18 |
+16 |                  A-----A-----A-----A           S
+14 | A--A--A--A--A-A                          S
+12 | S--S--S--S--S-S--S-----S-----S-----S
+10 |
+   +--+--+--+--+--+--+-----+-----+-----+-----+-----+
+   1  5  10 25 50 100 200   500  1000  2000  4000  8000  trees
+
+   S = SoA    A = AoS
+   |---- L1 ----||------- L2 ------||--- L3 ---|
+```
+
+## Analysis
+
+### Q1: Both fit in L1 (≤50 trees) — does AoS win?
+
+**No. SoA is 7–13% faster even when everything fits in L1.**
+
+This contradicts the earlier finding (Go 1.21) that AoS was 5% faster per-tree.
+On Go 1.24, the SoA path is consistently faster at all scales. Two factors:
+
+1. **Data efficiency**: The SoA numerical hot path loads only the 4 fields it needs
+   (`LeftChild`, `SplitIndex`, `SplitCondition`, `DefaultLeft` = 13 bytes/node).
+   The AoS path copies the full 24-byte struct including `RightChild`, `Category`,
+   `SplitType`, and `IsLeaf` — fields that are either unused in the numerical path
+   or redundant (`IsLeaf` ≡ `LeftChild < 0`). That's 85% more data loaded per node.
+
+2. **Compiler improvements**: Go 1.24 has better bounds check elimination for
+   sequential array accesses. The SoA pattern (`array[idx]` across separate slices
+   with the same index) is a pattern the compiler optimizes well.
+
+When both layouts fit in L1, cache miss rates are ~0 for both. The difference is
+purely instruction-level: fewer bytes moved, fewer wasted loads.
+
+### Q2: Neither fits in cache (≥4000 trees) — does SoA's advantage hold?
+
+**Yes, and it grows. SoA's advantage increases from ~1.1× (L1) to ~1.6× (L3).**
+
+The scaling pattern shows three distinct phases:
+
+| Phase | Trees | AoS/SoA ratio | Mechanism |
+|-------|-------|---------------|-----------|
+| L1-resident | 1–100 | 1.07–1.13× | Instruction-level: struct copy overhead |
+| L2-resident | 200–2000 | 1.37–1.45× | L1 miss penalty: AoS spills first, SoA arrays stay compact |
+| L2-spilling | 4000–8000 | 1.57–1.61× | L2 miss penalty: each miss costs ~10× more |
+
+The key observation: **SoA's per-tree cost is nearly flat from 1 to 2000 trees**
+(~12 ns/tree), only rising at 4000+ when it approaches the L2 boundary. AoS
+degrades earlier and more sharply at each cache tier boundary.
+
+Why does the gap widen? Cache miss penalties are asymmetric across tiers:
+- L1 hit: ~1 ns
+- L2 hit: ~5 ns
+- L3 hit: ~20 ns
+
+When AoS starts hitting L2 (at ~200 trees) while SoA is still in L1, each AoS
+node access pays a ~4 ns penalty. When both start hitting L3 (at ~4000+ trees),
+AoS's 1.4× larger footprint means 1.4× more L3 misses, each costing ~15 ns more.
+The absolute cost of being larger grows with miss penalty.
+
+### Why the 100-tree result was misleading
+
+The original 100-tree benchmark sits right at the L1 boundary — SoA's 38 KB fits,
+AoS's 54 KB barely spills. This created the appearance that the SoA advantage was
+specifically about L1/L2 cache pressure at this particular ensemble size.
+
+In reality, SoA wins at **every** scale tested:
+- Small: wins on data efficiency (fewer bytes per node access)
+- Medium: wins because smaller footprint delays cache tier transitions
+- Large: wins because smaller footprint means fewer misses at expensive tiers
+
+The advantage is monotonically increasing with ensemble size.
+
+## Methodology notes
+
+- Trees were deep-copied (not aliased) to ensure each tree has distinct memory
+  allocations, matching real-world heap layout
+- For tree counts > 100, trees cycle through the 100 source trees (tree `i` is a
+  deep copy of source tree `i % 100`), preserving realistic tree structure variety
+- Benchmarks measure raw tree iteration without the sigmoid/accumulation overhead
+  to isolate the data layout effect
+- The feature vector (44 × float32 = 176 bytes) is tiny and always L1-resident


### PR DESCRIPTION
## Summary

This PR adds comprehensive cache-scaling benchmarks and analysis to understand how the SoA (Structure of Arrays) vs AoS (Array of Structures) data layout choices perform across different ensemble sizes, from 1 tree to 8000 trees.

## Changes

- **`cache_bench_test.go`**: New benchmark suite with:
  - `BenchmarkCacheScalingSoA`: Measures SoA ensemble prediction performance across 12 tree count thresholds (1–8000 trees)
  - `BenchmarkCacheScalingAoS`: Equivalent benchmark for AoS layout
  - `TestTreeMemoryFootprint`: Diagnostic test that calculates and logs actual per-tree and ensemble memory footprints, cache tier boundaries, and scaling characteristics
  - Helper functions `makeSoATrees` and `makeAoSTrees` for creating deep-copied tree ensembles with independent memory allocations

- **`docs/cache-scaling-analysis.md`**: Detailed analysis document covering:
  - Corrected memory footprints based on actual mortgage model (23 nodes/tree avg, not 127)
  - Cache boundary calculations (L1: 48 KB, L2: 2 MB per core)
  - Benchmark results table showing SoA consistently outperforms AoS by 7–61% depending on ensemble size
  - Per-tree cost analysis showing SoA remains flat (~12 ns/tree) while AoS degrades at cache tier boundaries
  - Explanation of why SoA's advantage grows with ensemble size due to asymmetric cache miss penalties

## Key Findings

- **Small ensembles (≤100 trees, L1-resident)**: SoA is 7–13% faster due to lower instruction overhead (fewer bytes loaded per node)
- **Medium ensembles (200–2000 trees, L2-resident)**: SoA is 37–45% faster as AoS spills to L2 earlier
- **Large ensembles (4000–8000 trees, L2-spilling)**: SoA is 57–61% faster as both layouts hit L3, but AoS's larger footprint incurs more expensive misses

The analysis confirms that SoA's advantage is not specific to the 100-tree benchmark but is monotonically increasing with ensemble size, driven by smaller memory footprint delaying and reducing cache tier transitions.

## Testing

Benchmarks are designed to:
- Use deep-copied trees to match real-world heap layout (no aliased backing arrays)
- Cycle through source trees for large counts to maintain realistic tree structure variety
- Isolate the data layout effect by measuring raw tree iteration without sigmoid/accumulation overhead

https://claude.ai/code/session_01KGYEJezuTJq8zKyEgcJcxa